### PR TITLE
chore: Add crossorigin for preload translation header

### DIFF
--- a/edge-lambdas/dist/viewer-request/index.js
+++ b/edge-lambdas/dist/viewer-request/index.js
@@ -245,7 +245,7 @@ const addPreloadHeader = ({ response, request, translationVersion, appVersion })
     // we use the version of the app. The default language is deployed together with the app, and not
     // separately, so it follows the app versioning and the translations versioning.
     const hash = language === DEFAULT_LANGUAGE ? appVersion : translationVersion;
-    headers = setHeader(headers, 'Link', `</static/translations/${language}/messages.${hash}.js>; rel="preload"; as="script"`);
+    headers = setHeader(headers, 'Link', `</static/translations/${language}/messages.${hash}.js>; rel="preload"; as="script"; crossorigin`);
     return Object.assign(Object.assign({}, response), { headers });
 };
 /**

--- a/edge-lambdas/dist/viewer-response/index.js
+++ b/edge-lambdas/dist/viewer-response/index.js
@@ -226,7 +226,7 @@ const addPreloadHeader = ({ response, request, translationVersion, appVersion })
     // we use the version of the app. The default language is deployed together with the app, and not
     // separately, so it follows the app versioning and the translations versioning.
     const hash = language === DEFAULT_LANGUAGE ? appVersion : translationVersion;
-    headers = utils_setHeader(headers, 'Link', `</static/translations/${language}/messages.${hash}.js>; rel="preload"; as="script"`);
+    headers = utils_setHeader(headers, 'Link', `</static/translations/${language}/messages.${hash}.js>; rel="preload"; as="script"; crossorigin`);
     return Object.assign(Object.assign({}, response), { headers });
 };
 /**

--- a/edge-lambdas/src/addons/translations.ts
+++ b/edge-lambdas/src/addons/translations.ts
@@ -137,7 +137,7 @@ export const addPreloadHeader = ({
     headers = setHeader(
         headers,
         'Link',
-        `</static/translations/${language}/messages.${hash}.js>; rel="preload"; as="script"`
+        `</static/translations/${language}/messages.${hash}.js>; rel="preload"; as="script"; crossorigin`
     )
 
     return {...response, headers}

--- a/edge-lambdas/src/viewer-response/viewer-response.test.ts
+++ b/edge-lambdas/src/viewer-response/viewer-response.test.ts
@@ -332,7 +332,7 @@ const getTranslationHeaders = ({
             ? [
                   {
                       key: 'Link',
-                      value: `</static/translations/${language}/messages.${preloadHash}.js>; rel="preload"; as="script"`
+                      value: `</static/translations/${language}/messages.${preloadHash}.js>; rel="preload"; as="script"; crossorigin`
                   }
               ]
             : undefined


### PR DESCRIPTION
https://linear.app/pleo/issue/HMS-1133/preloading-messages-is-not-working

With "crossorigin" attr for the link preload, the problem with unused preload translation file should be gone.

Test:
https://preview-85a9f8beafafb08c4305604bcb08070a45a3da3c.app.staging.pleo.io/expenses
I hard-coded `/static/translations/es/messages.4437532041.js` into index.html to test `crossorigin`. With the attribute the warning is gone. If you change the language from "es" to another, it is possible to see a warning of unused preload.